### PR TITLE
add IndexHint to support not indexing a particular vertex

### DIFF
--- a/securegraph-accumulo/src/main/java/org/securegraph/accumulo/AccumuloElement.java
+++ b/securegraph-accumulo/src/main/java/org/securegraph/accumulo/AccumuloElement.java
@@ -47,7 +47,7 @@ public abstract class AccumuloElement<T extends Element> extends ElementBase<T> 
 
         Iterable<Property> properties = mutation.getProperties();
         updatePropertiesInternal(properties);
-        getGraph().saveProperties((AccumuloElement) mutation.getElement(), properties, authorizations);
+        getGraph().saveProperties((AccumuloElement) mutation.getElement(), properties, mutation.getIndexHint(), authorizations);
 
         if (mutation.getNewElementVisibility() != null) {
             getGraph().alterElementVisibility((AccumuloElement) mutation.getElement(), mutation.getNewElementVisibility());

--- a/securegraph-accumulo/src/main/java/org/securegraph/accumulo/AccumuloGraph.java
+++ b/securegraph-accumulo/src/main/java/org/securegraph/accumulo/AccumuloGraph.java
@@ -19,6 +19,7 @@ import org.securegraph.mutation.AlterPropertyMetadata;
 import org.securegraph.mutation.AlterPropertyVisibility;
 import org.securegraph.property.MutableProperty;
 import org.securegraph.property.StreamingPropertyValue;
+import org.securegraph.search.IndexHint;
 import org.securegraph.search.SearchIndex;
 import org.securegraph.util.CloseableIterable;
 import org.securegraph.util.EmptyClosableIterable;
@@ -144,14 +145,16 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex {
 
                 elementMutationBuilder.saveVertex(vertex);
 
-                getSearchIndex().addElement(AccumuloGraph.this, vertex, authorizations);
+                if (getIndexHint() != IndexHint.DO_NOT_INDEX) {
+                    getSearchIndex().addElement(AccumuloGraph.this, vertex, authorizations);
+                }
 
                 return vertex;
             }
         };
     }
 
-    void saveProperties(AccumuloElement element, Iterable<Property> properties, Authorizations authorizations) {
+    void saveProperties(AccumuloElement element, Iterable<Property> properties, IndexHint indexHint, Authorizations authorizations) {
         String rowPrefix = getRowPrefixForElement(element);
 
         String elementRowKey = rowPrefix + element.getId();
@@ -164,7 +167,10 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex {
         if (hasProperty) {
             addMutations(getWriterFromElementType(element), m);
         }
-        getSearchIndex().addElement(this, element, authorizations);
+
+        if (indexHint != IndexHint.DO_NOT_INDEX) {
+            getSearchIndex().addElement(this, element, authorizations);
+        }
     }
 
     void removeProperty(AccumuloElement element, Property property, Authorizations authorizations) {
@@ -297,7 +303,10 @@ public class AccumuloGraph extends GraphBaseWithSearchIndex {
                     ((AccumuloVertex) getInVertex()).addInEdge(edge);
                 }
 
-                getSearchIndex().addElement(AccumuloGraph.this, edge, authorizations);
+                if (getIndexHint() != IndexHint.DO_NOT_INDEX) {
+                    getSearchIndex().addElement(AccumuloGraph.this, edge, authorizations);
+                }
+
                 return edge;
             }
         };

--- a/securegraph-core/src/main/java/org/securegraph/ElementBuilder.java
+++ b/securegraph-core/src/main/java/org/securegraph/ElementBuilder.java
@@ -2,6 +2,7 @@ package org.securegraph;
 
 import org.securegraph.mutation.ElementMutation;
 import org.securegraph.property.MutablePropertyImpl;
+import org.securegraph.search.IndexHint;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,6 +13,7 @@ import static org.securegraph.util.Preconditions.checkNotNull;
 
 public abstract class ElementBuilder<T extends Element> implements ElementMutation<T> {
     private final List<Property> properties = new ArrayList<Property>();
+    private IndexHint indexHint = IndexHint.INDEX;
 
     /**
      * Sets or updates a property value. The property key will be set to a constant. This is a convenience method
@@ -91,5 +93,15 @@ public abstract class ElementBuilder<T extends Element> implements ElementMutati
 
     public Iterable<Property> getProperties() {
         return properties;
+    }
+
+    public IndexHint getIndexHint() {
+        return indexHint;
+    }
+
+    @Override
+    public ElementMutation<T> setIndexHint(IndexHint indexHint) {
+        this.indexHint = indexHint;
+        return this;
     }
 }

--- a/securegraph-core/src/main/java/org/securegraph/mutation/ElementMutation.java
+++ b/securegraph-core/src/main/java/org/securegraph/mutation/ElementMutation.java
@@ -4,6 +4,7 @@ import org.securegraph.Authorizations;
 import org.securegraph.Element;
 import org.securegraph.Property;
 import org.securegraph.Visibility;
+import org.securegraph.search.IndexHint;
 
 import java.util.Map;
 
@@ -67,4 +68,9 @@ public interface ElementMutation<T extends Element> {
      * Gets the properties currently in this mutation.
      */
     Iterable<Property> getProperties();
+
+    /**
+     * Sets the index hint of this element.
+     */
+    ElementMutation<T> setIndexHint(IndexHint indexHint);
 }

--- a/securegraph-core/src/main/java/org/securegraph/mutation/ExistingElementMutationImpl.java
+++ b/securegraph-core/src/main/java/org/securegraph/mutation/ExistingElementMutationImpl.java
@@ -5,6 +5,7 @@ import org.securegraph.Element;
 import org.securegraph.Property;
 import org.securegraph.Visibility;
 import org.securegraph.property.MutablePropertyImpl;
+import org.securegraph.search.IndexHint;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,6 +20,7 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
     private final List<AlterPropertyVisibility> alterPropertyVisibilities = new ArrayList<AlterPropertyVisibility>();
     private final List<AlterPropertyMetadata> alterPropertyMetadatas = new ArrayList<AlterPropertyMetadata>();
     private final T element;
+    private IndexHint indexHint = IndexHint.INDEX;
 
     public ExistingElementMutationImpl(T element) {
         this.element = element;
@@ -104,5 +106,15 @@ public abstract class ExistingElementMutationImpl<T extends Element> implements 
 
     public List<AlterPropertyMetadata> getAlterPropertyMetadatas() {
         return alterPropertyMetadatas;
+    }
+
+    public IndexHint getIndexHint() {
+        return indexHint;
+    }
+
+    @Override
+    public ElementMutation<T> setIndexHint(IndexHint indexHint) {
+        this.indexHint = indexHint;
+        return this;
     }
 }

--- a/securegraph-core/src/main/java/org/securegraph/search/IndexHint.java
+++ b/securegraph-core/src/main/java/org/securegraph/search/IndexHint.java
@@ -1,0 +1,13 @@
+package org.securegraph.search;
+
+public enum IndexHint {
+    /**
+     * Index the element in the search index.
+     */
+    INDEX,
+
+    /**
+     * Do not index the element in the search index.
+     */
+    DO_NOT_INDEX
+}

--- a/securegraph-inmemory/src/main/java/org/securegraph/inmemory/InMemoryElement.java
+++ b/securegraph-inmemory/src/main/java/org/securegraph/inmemory/InMemoryElement.java
@@ -63,7 +63,7 @@ public abstract class InMemoryElement<T extends Element> extends ElementBase<T> 
     protected <TElement extends Element> void saveExistingElementMutation(ExistingElementMutationImpl<TElement> mutation, Authorizations authorizations) {
         Iterable<Property> properties = mutation.getProperties();
         updatePropertiesInternal(properties);
-        getGraph().saveProperties(mutation.getElement(), properties, authorizations);
+        getGraph().saveProperties(mutation.getElement(), properties, mutation.getIndexHint(), authorizations);
 
         if (mutation.getElement() instanceof Edge) {
             if (mutation.getNewElementVisibility() != null) {

--- a/securegraph-inmemory/src/main/java/org/securegraph/inmemory/InMemoryGraph.java
+++ b/securegraph-inmemory/src/main/java/org/securegraph/inmemory/InMemoryGraph.java
@@ -6,6 +6,7 @@ import org.securegraph.id.UUIDIdGenerator;
 import org.securegraph.mutation.AlterPropertyMetadata;
 import org.securegraph.mutation.AlterPropertyVisibility;
 import org.securegraph.search.DefaultSearchIndex;
+import org.securegraph.search.IndexHint;
 import org.securegraph.search.SearchIndex;
 import org.securegraph.util.LookAheadIterable;
 
@@ -70,7 +71,9 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
                 InMemoryVertex vertex = new InMemoryVertex(InMemoryGraph.this, getVertexId(), getVisibility(), properties, authorizations);
                 vertices.put(getVertexId(), vertex);
 
-                getSearchIndex().addElement(InMemoryGraph.this, vertex, authorizations);
+                if (getIndexHint() != IndexHint.DO_NOT_INDEX) {
+                    getSearchIndex().addElement(InMemoryGraph.this, vertex, authorizations);
+                }
 
                 return vertex;
             }
@@ -139,7 +142,9 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
                 InMemoryEdge edge = new InMemoryEdge(InMemoryGraph.this, getEdgeId(), getOutVertex().getId(), getInVertex().getId(), getLabel(), getVisibility(), properties, authorizations);
                 edges.put(getEdgeId(), edge);
 
-                getSearchIndex().addElement(InMemoryGraph.this, edge, authorizations);
+                if (getIndexHint() != IndexHint.DO_NOT_INDEX) {
+                    getSearchIndex().addElement(InMemoryGraph.this, edge, authorizations);
+                }
 
                 return edge;
             }
@@ -217,7 +222,7 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         return authorizations.canRead(visibility);
     }
 
-    public void saveProperties(Element element, Iterable<Property> properties, Authorizations authorizations) {
+    public void saveProperties(Element element, Iterable<Property> properties, IndexHint indexHint, Authorizations authorizations) {
         if (element instanceof Vertex) {
             InMemoryVertex vertex = vertices.get(element.getId());
             vertex.updatePropertiesInternal(properties);
@@ -227,7 +232,10 @@ public class InMemoryGraph extends GraphBaseWithSearchIndex {
         } else {
             throw new IllegalArgumentException("Unexpected element type: " + element.getClass().getName());
         }
-        getSearchIndex().addElement(this, element, authorizations);
+
+        if (indexHint != IndexHint.DO_NOT_INDEX) {
+            getSearchIndex().addElement(this, element, authorizations);
+        }
     }
 
     public void removeProperty(Element element, Property property, Authorizations authorizations) {


### PR DESCRIPTION
the index hint can be specified on mutations and prepareVertex. If the index hint is DO_NOT_INDEX, SecureGraph will not index that edge/vertex in the search index.
